### PR TITLE
fix: remove header elements and revert to older version

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -29,10 +29,6 @@
             </svg>
         </button>
 
-        <header>
-            <h1>Course Materials Assistant</h1>
-            <p class="subtitle">Ask questions about courses, instructors, and content</p>
-        </header>
 
         <div class="main-content">
             <!-- Left Sidebar -->

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -46,26 +46,6 @@ body {
     padding: 0;
 }
 
-/* Header - Hidden */
-header {
-    display: none;
-}
-
-header h1 {
-    font-size: 1.75rem;
-    font-weight: 700;
-    background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
-    -webkit-background-clip: text;
-    -webkit-text-fill-color: transparent;
-    background-clip: text;
-    margin: 0;
-}
-
-.subtitle {
-    font-size: 0.95rem;
-    color: var(--text-secondary);
-    margin-top: 0.5rem;
-}
 
 /* Main Content Area with Sidebar */
 .main-content {
@@ -788,13 +768,6 @@ details[open] .suggested-header::before {
         order: 1;
     }
     
-    header {
-        padding: 1rem;
-    }
-    
-    header h1 {
-        font-size: 1.5rem;
-    }
     
     .chat-messages {
         padding: 1rem;


### PR DESCRIPTION
Fixes #2

This PR removes the header elements to revert to the older version while preserving the theme toggle functionality.

## Changes
- Remove "Course Material Assistant" header title
- Remove subheader about asking questions
- Remove all header-related CSS styles
- Preserve theme toggle functionality

Generated with [Claude Code](https://claude.ai/code)